### PR TITLE
Add TypeScript type definitions from DefinitelyTyped

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,13 +2,13 @@
 
 In these API docs, a **higher-order component** (HOC) refers to a function that accepts a single React component and returns a new React component.
 
-```js
+```ts
 const EnhancedComponent = hoc(BaseComponent)
 ```
 
 This form makes HOCs (sometimes called **enhancers**) composable:
 
-```js
+```ts
 const composedHoc = compose(hoc1, hoc2, hoc3)
 
 // Same as
@@ -17,7 +17,7 @@ const composedHoc = BaseComponent => hoc1(hoc2(hoc3(BaseComponent)))
 
 Most Recompose helpers are **functions that return higher-order components**:
 
-```js
+```ts
 const hoc = mapProps(ownerProps => childProps)
 const EnhancedComponent = hoc(BaseComponent)
 
@@ -27,7 +27,7 @@ const EnhancedComponent = mapProps(ownerProps => childProps)(BaseComponent)
 
 Some, like `pure`, are higher-order components themselves:
 
-```js
+```ts
 const PureComponent = pure(BaseComponent)
 ```
 
@@ -85,7 +85,7 @@ const PureComponent = pure(BaseComponent)
 
 ### `mapProps()`
 
-```js
+```ts
 mapProps(
   propsMapper: (ownerProps: Object) => Object,
 ): HigherOrderComponent
@@ -95,7 +95,7 @@ Accepts a function that maps owner props to a new collection of props that are p
 
 `mapProps()` pairs well with functional utility libraries like [lodash/fp](https://github.com/lodash/lodash/tree/npm/fp). For example, Recompose does not come with a `omitProps()` function, but you can easily build one using lodash-fp's `omit()`:
 
-```js
+```ts
 const omitProps = keys => mapProps(props => omit(keys, props))
 
 // Because of currying in lodash-fp, this is the same as
@@ -104,7 +104,7 @@ const omitProps = compose(mapProps, omit)
 
 ### `withProps()`
 
-```js
+```ts
 withProps(
   createProps: (ownerProps: Object) => Object | Object
 ): HigherOrderComponent
@@ -117,7 +117,7 @@ Instead of a function, you can also pass a props object directly. In this form, 
 
 ### `withPropsOnChange()`
 
-```js
+```ts
 withPropsOnChange(
   shouldMapOrKeys: Array<string> | (props: Object, nextProps: Object) => boolean,
   createProps: (ownerProps: Object) => Object
@@ -130,7 +130,7 @@ Instead of an array of prop keys, the first parameter can also be a function tha
 
 ### `withHandlers()`
 
-```js
+```ts
 withHandlers(
   handlerCreators: {
     [handlerName: string]: (props: Object) => Function
@@ -149,7 +149,7 @@ Handlers are passed to the base component as immutable props, whose identities a
 
 Usage example:
 
-```js
+```ts
 const enhance = compose(
   withState('value', 'updateValue', ''),
   withHandlers({
@@ -174,7 +174,7 @@ const Form = enhance(({ value, onChange, onSubmit }) =>
 
 ### `defaultProps()`
 
-```js
+```ts
 defaultProps(
   props: Object
 ): HigherOrderComponent
@@ -187,7 +187,7 @@ Although it has a similar effect, using the `defaultProps()` HoC is *not* the sa
 
 ### `renameProp()`
 
-```js
+```ts
 renameProp(
   oldName: string,
   newName: string
@@ -198,7 +198,7 @@ Renames a single prop.
 
 Example:
 
-```js
+```ts
 const enhance = compose(
   withProps({ 'loadingDataFromApi': true, 'posts': [] }),
   renameProp('loadingDataFromApi', 'isLoading'),
@@ -217,7 +217,7 @@ const Posts = enhance(({ isLoading, items }) => (
 
 ### `renameProps()`
 
-```js
+```ts
 renameProps(
   nameMap: { [key: string]: string }
 ): HigherOrderComponent
@@ -227,7 +227,7 @@ Renames multiple props, using a map of old prop names to new prop names.
 
 Example:
 
-```js
+```ts
 const enhance = compose(
   withProps({ 'loadingDataFromApi': true, 'posts': [] }),
   renameProps({ 'loadingDataFromApi': 'isLoading', 'posts': 'items' }),
@@ -245,7 +245,7 @@ const Posts = enhance(({ isLoading, items }) => (
 
 ### `flattenProp()`
 
-```js
+```ts
 flattenProp(
   propName: string
 ): HigherOrderComponent
@@ -253,7 +253,7 @@ flattenProp(
 
 Flattens a prop so that its fields are spread out into the props object.
 
-```js
+```ts
 const enhance = compose(
   withProps({
     object: { a: 'a', b: 'b' },
@@ -268,7 +268,7 @@ const Abc = enhance(BaseComponent)
 
 An example use case for `flattenProp()` is when receiving fragment data from Relay. Relay fragments are passed as an object of props, which you often want flattened out into its constituent fields:
 
-```js
+```ts
 // The `post` prop is an object with title, author, and content fields
 const enhance = flattenProp('post')
 const Post = enhance(({ title, content, author }) =>
@@ -282,24 +282,24 @@ const Post = enhance(({ title, content, author }) =>
 
 ### `withState()`
 
-```js
-withState(
+```ts
+// TState = the type of the state value
+withState<TState>(
   stateName: string,
   stateUpdaterName: string,
-  initialState: any | (props: Object) => any
+  initialState: TState | ((props: Object) => TState)
 ): HigherOrderComponent
 ```
 
 Passes two additional props to the base component: a state value, and a function to update that state value. The state updater has the following signature:
 
-```js
-stateUpdater<T>((prevValue: T) => T, ?callback: Function): void
-stateUpdater(newValue: any, ?callback: Function): void
+```ts
+stateUpdater(updateFn: TState | ((prevValue: TState) => TState), callback?: () => void): void
 ```
 
 The first form accepts a function which maps the previous state value to a new state value. You'll likely want to use this state updater along with `withHandlers()` to create specific updater functions. For example, to create a HoC that adds basic counting functionality to a component:
 
-```js
+```ts
 const addCounting = compose(
   withState('counter', 'setCounter', 0),
   withHandlers({
@@ -318,14 +318,14 @@ An initial state value is required. It can be either the state value itself, or 
 
 ### `withStateHandlers()`
 
-```js
-withStateHandlers(
-  initialState: Object | (props: Object) => any,
+```ts
+// TState = the type of the state object
+withStateHandlers<TState>(
+  initialState: TState | ((props: Object) => TState),
   stateUpdaters: {
-    [key: string]: (state:Object, props:Object) => (...payload: any[]) => Object
+    [key: string]: (state: TState, props: Object) => (...payload: any[]) => Partial<TState> | undefined
   }
-)
-
+): HigherOrderComponent
 ```
 
 Passes state object properties and immutable updater functions
@@ -336,7 +336,7 @@ Returning undefined does not cause a component rerender.
 
 Example:
 
-```js
+```ts
   const Counter = withStateHandlers(
     ({ initialCounter = 0 }) => ({
       counter: initialCounter,
@@ -364,12 +364,13 @@ Example:
 
 ### `withReducer()`
 
-```js
-withReducer<S, A>(
+```ts
+// TState = the type of the state value, TAction = the type of dispatched actions
+withReducer<TState, TAction>(
   stateName: string,
   dispatchName: string,
-  reducer: (state: S, action: A) => S,
-  initialState: S | (ownerProps: Object) => S
+  reducer: (state: TState, action: TAction) => TState,
+  initialState: TState | ((ownerProps: Object) => TState)
 ): HigherOrderComponent
 ```
 
@@ -377,19 +378,19 @@ Similar to `withState()`, but state updates are applied using a reducer function
 
 Passes two additional props to the base component: a state value, and a dispatch method. The dispatch method has the following signature:
 
-```js
-dispatch(action: Object, ?callback: Function): void
+```ts
+dispatch(action: TAction, callback?: (newState: TState) => void): void
 ```
 
 It sends an action to the reducer, after which the new state is applied. It also accepts an optional second parameter, a callback function with the new state as its only argument.
 
 ### `branch()`
 
-```js
+```ts
 branch(
   test: (props: Object) => boolean,
   left: HigherOrderComponent,
-  right: ?HigherOrderComponent
+  right?: HigherOrderComponent
 ): HigherOrderComponent
 ```
 
@@ -397,7 +398,7 @@ Accepts a test function and two higher-order components. The test function is pa
 
 ### `renderComponent()`
 
-```js
+```ts
 renderComponent(
   Component: ReactClass | ReactFunctionalComponent | string
 ): HigherOrderComponent
@@ -407,7 +408,7 @@ Takes a component and returns a higher-order component version of that component
 
 This is useful in combination with another helper that expects a higher-order component, like `branch()`:
 
-```js
+```ts
 // `isLoading()` is a function that returns whether or not the component
 // is in a loading state
 const spinnerWhileLoading = isLoading =>
@@ -432,7 +433,7 @@ const Post = enhance(({ title, author, content }) =>
 
 ### `renderNothing()`
 
-```js
+```ts
 renderNothing: HigherOrderComponent
 ```
 
@@ -440,7 +441,7 @@ A higher-order component that always renders `null`.
 
 This is useful in combination with another helper that expects a higher-order component, like `branch()`:
 
-```js
+```ts
 // `hasNoData()` is a function that returns true if the component has
 // no data
 const hideIfNoData = hasNoData =>
@@ -464,7 +465,7 @@ const Post = enhance(({ title, author, content }) =>
 
 ### `shouldUpdate()`
 
-```js
+```ts
 shouldUpdate(
   test: (props: Object, nextProps: Object) => boolean
 ): HigherOrderComponent
@@ -475,7 +476,7 @@ Higher-order component version of [`shouldComponentUpdate()`](https://facebook.g
 
 ### `pure()`
 
-```js
+```ts
 pure: HigherOrderComponent
 ```
 
@@ -483,7 +484,7 @@ Prevents the component from updating unless a prop has changed. Uses `shallowEqu
 
 ### `onlyUpdateForKeys()`
 
-```js
+```ts
 onlyUpdateForKeys(
   propKeys: Array<string>
 ): HigherOrderComponent
@@ -495,7 +496,7 @@ This is a much better optimization than the popular approach of using PureRender
 
 Example:
 
-```js
+```ts
 /**
  * If the owner passes unnecessary props (say, an array of comments), it will
  * not lead to wasted render cycles.
@@ -515,7 +516,7 @@ const Post = enhance(({ title, content, author }) =>
 
 ### `onlyUpdateForPropTypes()`
 
-```js
+```ts
 onlyUpdateForPropTypes: HigherOrderComponent
 ```
 
@@ -523,7 +524,7 @@ Works like `onlyUpdateForKeys()`, but prop keys are inferred from the `propTypes
 
 If the base component does not have any `propTypes`, the component will never receive any updates. This probably isn't the expected behavior, so a warning is printed to the console.
 
-```js
+```ts
 import PropTypes from 'prop-types'; // You need to import prop-types. See https://facebook.github.io/react/docs/typechecking-with-proptypes.html
 
 const enhance = compose(
@@ -546,10 +547,11 @@ const Post = enhance(({ title, content, author }) =>
 
 ### `withContext()`
 
-```js
-withContext(
-  childContextTypes: Object,
-  getChildContext: (props: Object) => Object
+```ts
+// TContext = the type of the provided child context
+withContext<TContext>(
+  childContextTypes: PropTypes.ValidationMap<TContext>,
+  getChildContext: (props: Object) => TContext
 ): HigherOrderComponent
 ```
 
@@ -557,7 +559,7 @@ Provides context to the component's children. `childContextTypes` is an object o
 
 ### `getContext()`
 
-```js
+```ts
 getContext(
   contextTypes: Object
 ): HigherOrderComponent
@@ -567,7 +569,7 @@ Gets values from context and passes them along as props. Use along with `withCon
 
 ### `lifecycle()`
 
-```js
+```ts
 lifecycle(
   spec: Object,
 ): HigherOrderComponent
@@ -578,7 +580,7 @@ A higher-order component version of [`React.Component()`](https://facebook.githu
 Any state changes made in a lifecycle method, by using `setState`, will be propagated to the wrapped component as props.
 
 Example:
-```js
+```ts
 const PostsList = ({ posts }) => (
   <ul>{posts.map(p => <li>{p.title}</li>)}</ul>
 )
@@ -594,7 +596,7 @@ const PostsListWithData = lifecycle({
 
 ### `toClass()`
 
-```js
+```ts
 toClass: HigherOrderComponent
 ```
 
@@ -605,7 +607,7 @@ If the base component is already a class, it returns the given component.
 
 ### `toRenderProps()`
 
-```js
+```ts
 toRenderProps(
   hoc: HigherOrderComponent
 ): ReactFunctionalComponent
@@ -614,7 +616,7 @@ toRenderProps(
 Creates a component that accepts a function as a children with the high-order component applied to it. 
 
 Example:
-```js
+```ts
 const enhance = withProps(({ foo }) => ({ fooPlusOne: foo + 1 }))
 const Enhanced = toRenderProps(enhance)
 
@@ -624,7 +626,7 @@ const Enhanced = toRenderProps(enhance)
 
 ### `fromRenderProps()`
 
-```js
+```ts
 fromRenderProps(
   RenderPropsComponent: ReactClass | ReactFunctionalComponent,
   propsMapper: (...props: any[]) => Object,
@@ -638,7 +640,7 @@ The default value of third parameter (`renderPropName`) is `children`. You can u
 
 > Check the official documents [Render Props](https://reactjs.org/docs/render-props.html#using-props-other-than-render) for more details.
 
-```js
+```ts
 import { fromRenderProps } from 'recompose';
 const { Consumer: ThemeConsumer } = React.createContext({ theme: 'dark' });
 const { Consumer: I18NConsumer } = React.createContext({ i18n: 'en' });
@@ -676,7 +678,7 @@ These functions look like higher-order component helpers — they are curried an
 
 ### `setStatic()`
 
-```js
+```ts
 setStatic(
   key: string,
   value: any
@@ -687,7 +689,7 @@ Assigns a value to a static property on the base component.
 
 ### `setPropTypes()`
 
-```js
+```ts
 setPropTypes(
   propTypes: Object
 ): HigherOrderComponent
@@ -697,7 +699,7 @@ Assigns to the `propTypes` property on the base component.
 
 ### `setDisplayName()`
 
-```js
+```ts
 setDisplayName(
   displayName: string
 ): HigherOrderComponent
@@ -711,7 +713,7 @@ Recompose also includes some additional helpers that aren't higher-order compone
 
 ### `compose()`
 
-```js
+```ts
 compose(...functions: Array<Function>): Function
 ```
 
@@ -719,7 +721,7 @@ Use to compose multiple higher-order components into a single higher-order compo
 
 ### `getDisplayName()`
 
-```js
+```ts
 getDisplayName(
   component: ReactClass | ReactFunctionalComponent
 ): string
@@ -729,7 +731,7 @@ Returns the display name of a React component. Falls back to `'Component'`.
 
 ### `wrapDisplayName()`
 
-```js
+```ts
 wrapDisplayName(
   component: ReactClass | ReactFunctionalComponent,
   wrapperName: string
@@ -740,7 +742,7 @@ Returns a wrapped version of a React component's display name. For instance, if 
 
 ### `shallowEqual()`
 
-```js
+```ts
 shallowEqual(a: Object, b: Object): boolean
 ```
 
@@ -748,7 +750,7 @@ Returns true if objects are shallowly equal.
 
 ### `isClassComponent()`
 
-```js
+```ts
 isClassComponent(value: any): boolean
 ```
 
@@ -756,15 +758,16 @@ Returns true if the given value is a React component class.
 
 ### `createSink()`
 
-```js
-createSink(callback: (props: Object) => void): ReactClass
+```ts
+// TProps = the type of props passed to the callback
+createSink<TProps>(callback: (props: TProps) => void): ReactClass
 ```
 
 Creates a component that renders nothing (null) but calls a callback when receiving new props.
 
 ### `componentFromProp()`
 
-```js
+```ts
 componentFromProp(propName: string): ReactFunctionalComponent
 ```
 
@@ -772,7 +775,7 @@ Creates a component that accepts a component as a prop and renders it with the r
 
 Example:
 
-```js
+```ts
 const enhance = defaultProps({ component: 'button' })
 const Button = enhance(componentFromProp('component'))
 
@@ -783,7 +786,7 @@ const Button = enhance(componentFromProp('component'))
 
 ### `nest()`
 
-```js
+```ts
 nest(
   ...Components: Array<ReactClass | ReactFunctionalComponent | string>
 ): ReactClass
@@ -791,7 +794,7 @@ nest(
 
 Composes components by nesting each one inside the previous. For example:
 
-```js
+```ts
 // Given components A, B, and C
 const ABC = nest(A, B, C)
 <ABC pass="through">Child</ABC>
@@ -808,7 +811,7 @@ const ABC = nest(A, B, C)
 
 ### `hoistStatics()`
 
-```js
+```ts
 hoistStatics(
   hoc: HigherOrderComponent,
   blacklist: Object
@@ -821,11 +824,13 @@ Note that this only hoists _non-react_ statics. The following static properties 
 
 You can exclude more static properties by passing them as `blacklist` object:
 
-```js
+```ts
 hoistStatics(EnhancedComponent, { foo: true })(BaseComponent) // Exclude `foo`
 ```
 
 ## Observable utilities
+
+> **Note:** Type signatures in this section use pseudocode notation (e.g., `TStream<T>` for a generic stream type). TypeScript does not support higher-kinded types, so the actual `.d.ts` file uses `any` in place of `TStream<T>`. See `index.d.ts` for exact TypeScript types.
 
 It turns out that much of the React Component API can be expressed in terms of observables:
 
@@ -845,7 +850,7 @@ Other benefits include:
 
 ### `componentFromStream()`
 
-```js
+```ts
 componentFromStream(
   propsToReactNode: (props$: Observable<object>) => Observable<ReactNode>
 ): ReactComponent
@@ -855,7 +860,7 @@ Creates a React component by mapping an observable stream of props to a stream o
 
 You can think of `propsToReactNode` as a function `f` such that
 
-```js
+```ts
 const vdom$ = f(props$)
 ```
 
@@ -867,7 +872,7 @@ v = f(d)
 
 Example:
 
-```js
+```ts
 const Counter = componentFromStream(props$ => {
   const { handler: increment, stream: increment$ } = createEventHandler()
   const { handler: decrement, stream: decrement$ } = createEventHandler()
@@ -892,14 +897,15 @@ const Counter = componentFromStream(props$ => {
 
 ### `componentFromStreamWithConfig()`
 
-```js
-componentFromStreamWithConfig<Stream>(
+```ts
+// TStream = the stream/observable type used by your library (e.g., RxJS Observable, xstream Stream)
+componentFromStreamWithConfig<TStream>(
   config: {
-    fromESObservable<T>: ?(observable: Observable<T>) => Stream<T>,
-    toESObservable<T>: ?(stream: Stream<T>) => Observable<T>,
+    fromESObservable?: <T>(observable: Observable<T>) => TStream<T>,
+    toESObservable?: <T>(stream: TStream<T>) => Observable<T>,
   }
 ) => (
-  propsToReactNode: (props$: Stream<object>) => Stream<ReactNode>
+  propsToReactNode: (props$: TStream<object>) => TStream<ReactNode>
 ): ReactComponent
 ```
 
@@ -909,56 +915,56 @@ Alternative to `componentFromStream()` that accepts an observable config and ret
 
 #### RxJS
 
-```js
+```ts
 import rxjsConfig from 'recompose/rxjsObservableConfig'
 const componentFromStream = componentFromStreamWithConfig(rxjsConfig)
 ```
 
 #### RxJS 4 (legacy)
 
-```js
+```ts
 import rxjs4Config from 'recompose/rxjs4ObservableConfig'
 const componentFromStream = componentFromStreamWithConfig(rxjs4Config)
 ```
 
 #### most
 
-```js
+```ts
 import mostConfig from 'recompose/mostObservableConfig'
 const componentFromStream = componentFromStreamWithConfig(mostConfig)
 ```
 
 #### xstream
 
-```js
+```ts
 import xstreamConfig from 'recompose/xstreamObservableConfig'
 const componentFromStream = componentFromStreamWithConfig(xstreamConfig)
 ```
 
 #### Bacon
 
-```js
+```ts
 import baconConfig from 'recompose/baconObservableConfig'
 const componentFromStream = componentFromStreamWithConfig(baconConfig)
 ```
 
 #### Kefir
 
-```js
+```ts
 import kefirConfig from 'recompose/kefirObservableConfig'
 const componentFromStream = componentFromStreamWithConfig(kefirConfig)
 ```
 
 #### Flyd
 
-```js
+```ts
 import flydConfig from 'recompose/flydObservableConfig'
 const componentFromStream = componentFromStreamWithConfig(flydConfig)
 ```
 
 ### `mapPropsStream()`
 
-```js
+```ts
 mapPropsStream(
   ownerPropsToChildProps: (props$: Observable<object>) => Observable<object>,
   BaseComponent: ReactElementType
@@ -970,21 +976,22 @@ A higher-order component version of `componentFromStream()` — accepts a functi
 You may want to use this version to interoperate with other Recompose higher-order component helpers.
 
 ### `mapPropsStreamWithConfig()`
-```js
-mapPropsStreamWithConfig<Stream>(
+```ts
+// TStream = the stream/observable type used by your library
+mapPropsStreamWithConfig<TStream>(
   config: {
-    fromESObservable<T>: ?(observable: Observable<T>) => Stream<T>,
-    toESObservable<T>: ?(stream: Stream<T>) => Observable<T>,
+    fromESObservable?: <T>(observable: Observable<T>) => TStream<T>,
+    toESObservable?: <T>(stream: TStream<T>) => Observable<T>,
   },
 ) => (
-  ownerPropsToChildProps: (props$: Stream<object>) => Stream<object>,
+  ownerPropsToChildProps: (props$: TStream<object>) => TStream<object>,
   BaseComponent: ReactElementType
 ): ReactComponent
 ```
 
 Alternative to `mapPropsStream()` that accepts a observable config and returns a customized `mapPropsStream()` that uses the specified observable library. See `componentFromStreamWithConfig()` above.
 
-```js
+```ts
 const enhance = mapPropsStream(props$ => {
   const timeElapsed$ = Observable.interval(1000)
   return props$.combineLatest(timeElapsed$, (props, timeElapsed) => ({
@@ -1000,25 +1007,28 @@ const Timer = enhance(({ timeElapsed }) =>
 
 ### `createEventHandler()`
 
-```js
-createEventHandler<T>(): {
-  handler: (value: T) => void,
-  stream: Observable<T>
+```ts
+// TValue = the type of values pushed through the handler/stream
+createEventHandler<TValue>(): {
+  handler: (value: TValue) => void,
+  stream: Observable<TValue>
 }
 ```
 
 Returns an object with properties `handler` and `stream`. `stream` is an observable sequence, and `handler` is a function that pushes new values onto the sequence. Useful for creating event handlers like `onClick`.
 
 ### `createEventHandlerWithConfig()`
-```js
-createEventHandlerWithConfig<T>(
+```ts
+// TStream = the stream/observable type used by your library
+// TValue = the type of values pushed through the handler/stream
+createEventHandlerWithConfig<TStream>(
   config: {
-    fromESObservable<T>: ?(observable: Observable<T>) => Stream<T>,
-    toESObservable<T>: ?(stream: Stream<T>) => Observable<T>,
+    fromESObservable?: <T>(observable: Observable<T>) => TStream<T>,
+    toESObservable?: <T>(stream: TStream<T>) => Observable<T>,
   }
-) => (): {
-  handler: (value: T) => void,
-  stream: Observable<T>
+) => <TValue>(): {
+  handler: (value: TValue) => void,
+  stream: TStream<TValue>
 }
 ```
 
@@ -1026,10 +1036,11 @@ Alternative to `createEventHandler()` that accepts an observable config and retu
 
 ### `setObservableConfig()`
 
-```js
-setObservableConfig<Stream>({
-  fromESObservable<T>: ?(observable: Observable<T>) => Stream<T>,
-  toESObservable<T>: ?(stream: Stream<T>) => Observable<T>
+```ts
+// TStream = the stream/observable type used by your library
+setObservableConfig<TStream>({
+  fromESObservable?: <T>(observable: Observable<T>) => TStream<T>,
+  toESObservable?: <T>(stream: TStream<T>) => Observable<T>
 })
 ```
 
@@ -1037,7 +1048,7 @@ setObservableConfig<Stream>({
 
 Observables in Recompose are plain objects that conform to the [ES Observable proposal](https://github.com/zenparsing/es-observable). Usually, you'll want to use them alongside an observable library like RxJS so that you have access to its suite of operators. By default, this requires you to convert the observables provided by Recompose before applying any transforms:
 
-```js
+```ts
 mapPropsStream(props$ => {
   const rxjsProps$ = Rx.Observable.from(props$)
   // ...now you can use map, filter, scan, etc.
@@ -1047,7 +1058,7 @@ mapPropsStream(props$ => {
 
 This quickly becomes tedious. Rather than performing this transform for each stream individually, `setObservableConfig()` sets a global observable transform that is applied automatically.
 
-```js
+```ts
 import Rx from 'rxjs'
 import { setObservableConfig } from 'recompose'
 
@@ -1065,49 +1076,49 @@ Fortunately, you likely don't need to worry about how to configure Recompose for
 
 #### RxJS
 
-```js
+```ts
 import rxjsconfig from 'recompose/rxjsObservableConfig'
 setObservableConfig(rxjsconfig)
 ```
 
 #### RxJS 4 (legacy)
 
-```js
+```ts
 import rxjs4config from 'recompose/rxjs4ObservableConfig'
 setObservableConfig(rxjs4config)
 ```
 
 #### most
 
-```js
+```ts
 import mostConfig from 'recompose/mostObservableConfig'
 setObservableConfig(mostConfig)
 ```
 
 #### xstream
 
-```js
+```ts
 import xstreamConfig from 'recompose/xstreamObservableConfig'
 setObservableConfig(xstreamConfig)
 ```
 
 #### Bacon
 
-```js
+```ts
 import baconConfig from 'recompose/baconObservableConfig'
 setObservableConfig(baconConfig)
 ```
 
 #### Kefir
 
-```js
+```ts
 import kefirConfig from 'recompose/kefirObservableConfig'
 setObservableConfig(kefirConfig)
 ```
 
 #### Flyd
 
-```js
+```ts
 import flydConfig from 'recompose/flydObservableConfig'
 setObservableConfig(flydConfig)
 ```

--- a/src/packages/recompose/index.d.ts
+++ b/src/packages/recompose/index.d.ts
@@ -1,5 +1,5 @@
 // @shakacode/recompose is a fork of `recompose`, and these types are based on work done in `@types/recompose`.
-// Source: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/61bebf7cbfd07a3f7a28fd2d8df3ea10a0a8d0a3/types/shakacode__recompose/index.d.ts
+// Based on: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/61bebf7cbfd07a3f7a28fd2d8df3ea10a0a8d0a3/types/shakacode__recompose/index.d.ts
 
 /// <reference types="react" />
 
@@ -8,12 +8,9 @@ declare module "@shakacode/recompose" {
     import * as React from "react";
     import { ComponentClass, ComponentType as Component, FunctionComponent } from "react";
 
-    type mapper<TInner, TOutter> = (input: TInner) => TOutter;
+    type mapper<TInner, TOuter> = (input: TInner) => TOuter;
     type predicate<T> = mapper<T, boolean>;
     type predicateDiff<T> = (current: T, next: T) => boolean;
-
-    // Diff / Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
-    type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
     interface Observer<T> {
         next(props: T): void;
@@ -28,8 +25,8 @@ declare module "@shakacode/recompose" {
         subscribe(observer: Observer<T>): Subscription;
     }
 
-    interface ComponentEnhancer<TInner, TOutter> {
-        (component: Component<TInner>): ComponentClass<TOutter>;
+    interface ComponentEnhancer<TInner, TOuter> {
+        (component: Component<TInner>): ComponentClass<TOuter>;
     }
 
     // Injects props and removes them from the prop requirements.
@@ -56,41 +53,41 @@ declare module "@shakacode/recompose" {
     // Higher-order components: https://github.com/shakacode/recompose/blob/master/docs/API.md#higher-order-components
 
     // mapProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#mapprops
-    export function mapProps<TInner, TOutter>(
-        propsMapper: mapper<TOutter, TInner>,
-    ): InferableComponentEnhancerWithProps<TInner, TOutter>;
+    export function mapProps<TInner, TOuter>(
+        propsMapper: mapper<TOuter, TInner>,
+    ): InferableComponentEnhancerWithProps<TInner, TOuter>;
 
     // withProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#withprops
-    export function withProps<TInner, TOutter>(
-        createProps: TInner | mapper<TOutter, TInner>,
-    ): InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>;
+    export function withProps<TInner, TOuter>(
+        createProps: TInner | mapper<TOuter, TInner>,
+    ): InferableComponentEnhancerWithProps<TInner & TOuter, TOuter>;
 
     // withPropsOnChange: https://github.com/shakacode/recompose/blob/master/docs/API.md#withpropsonchange
-    export function withPropsOnChange<TInner, TOutter>(
-        shouldMapOrKeys: string[] | predicateDiff<TOutter>,
-        createProps: mapper<TOutter, TInner>,
-    ): InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>;
+    export function withPropsOnChange<TInner, TOuter>(
+        shouldMapOrKeys: string[] | predicateDiff<TOuter>,
+        createProps: mapper<TOuter, TInner>,
+    ): InferableComponentEnhancerWithProps<TInner & TOuter, TOuter>;
 
     // withHandlers: https://github.com/shakacode/recompose/blob/master/docs/API.md#withhandlers
     type EventHandler = Function;
-    // This type is required to infer TOutter
-    type HandleCreatorsStructure<TOutter> = {
-        [handlerName: string]: mapper<TOutter, EventHandler>;
+    // This type is required to infer TOuter
+    type HandleCreatorsStructure<TOuter> = {
+        [handlerName: string]: mapper<TOuter, EventHandler>;
     };
     // This type is required to infer THandlers
-    type HandleCreatorsHandlers<TOutter, THandlers> = {
-        [P in keyof THandlers]: (props: TOutter) => THandlers[P];
+    type HandleCreatorsHandlers<TOuter, THandlers> = {
+        [P in keyof THandlers]: (props: TOuter) => THandlers[P];
     };
-    type HandleCreators<TOutter, THandlers> =
-        & HandleCreatorsStructure<TOutter>
-        & HandleCreatorsHandlers<TOutter, THandlers>;
-    type HandleCreatorsFactory<TOutter, THandlers> = (initialProps: TOutter) => HandleCreators<TOutter, THandlers>;
+    type HandleCreators<TOuter, THandlers> =
+        & HandleCreatorsStructure<TOuter>
+        & HandleCreatorsHandlers<TOuter, THandlers>;
+    type HandleCreatorsFactory<TOuter, THandlers> = (initialProps: TOuter) => HandleCreators<TOuter, THandlers>;
 
-    export function withHandlers<TOutter, THandlers>(
+    export function withHandlers<TOuter, THandlers>(
         handlerCreators:
-            | HandleCreators<TOutter, THandlers>
-            | HandleCreatorsFactory<TOutter, THandlers>,
-    ): InferableComponentEnhancerWithProps<THandlers & TOutter, TOutter>;
+            | HandleCreators<TOuter, THandlers>
+            | HandleCreatorsFactory<TOuter, THandlers>,
+    ): InferableComponentEnhancerWithProps<THandlers & TOuter, TOuter>;
 
     // defaultProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#defaultprops
     export function defaultProps<T = {}>(
@@ -99,13 +96,13 @@ declare module "@shakacode/recompose" {
 
     // renameProp: https://github.com/shakacode/recompose/blob/master/docs/API.md#renameProp
     export function renameProp(
-        outterName: string,
+        outerName: string,
         innerName: string,
     ): ComponentEnhancer<any, any>;
 
     // renameProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#renameProps
     type NameMap = {
-        [outterName: string]: string;
+        [outerName: string]: string;
     };
     export function renameProps(
         nameMap: NameMap,
@@ -123,19 +120,19 @@ declare module "@shakacode/recompose" {
         TStateUpdaterName extends string,
     > =
         & { [stateName in TStateName]: TState }
-        & { [stateUpdateName in TStateUpdaterName]: (state: TState) => TState };
+        & { [stateUpdateName in TStateUpdaterName]: (updateFn: TState | ((prevState: TState) => TState), callback?: () => void) => void };
     export function withState<
-        TOutter,
+        TOuter,
         TState,
         TStateName extends string,
         TStateUpdaterName extends string,
     >(
         stateName: TStateName,
         stateUpdaterName: TStateUpdaterName,
-        initialState: TState | mapper<TOutter, TState>,
+        initialState: TState | mapper<TOuter, TState>,
     ): InferableComponentEnhancerWithProps<
         stateProps<TState, TStateName, TStateUpdaterName>,
-        TOutter
+        TOuter
     >;
 
     // withStateHandlers: https://github.com/shakacode/recompose/blob/master/docs/API.md#withstatehandlers
@@ -143,13 +140,13 @@ declare module "@shakacode/recompose" {
     type StateHandlerMap<TState> = {
         [updaterName: string]: StateHandler<TState>;
     };
-    type StateUpdaters<TOutter, TState, TUpdaters> = {
-        [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => TUpdaters[updaterName];
+    type StateUpdaters<TOuter, TState, TUpdaters> = {
+        [updaterName in keyof TUpdaters]: (state: TState, props: TOuter) => TUpdaters[updaterName];
     };
-    export function withStateHandlers<TState, TUpdaters extends StateHandlerMap<TState>, TOutter = {}>(
-        createProps: TState | mapper<TOutter, TState>,
-        stateUpdaters: StateUpdaters<TOutter, TState, TUpdaters>,
-    ): InferableComponentEnhancerWithProps<TOutter & TState & TUpdaters, TOutter>;
+    export function withStateHandlers<TState, TUpdaters extends StateHandlerMap<TState>, TOuter = {}>(
+        createProps: TState | mapper<TOuter, TState>,
+        stateUpdaters: StateUpdaters<TOuter, TState, TUpdaters>,
+    ): InferableComponentEnhancerWithProps<TOuter & TState & TUpdaters, TOuter>;
 
     // withReducer: https://github.com/shakacode/recompose/blob/master/docs/API.md#withReducer
     type reducer<TState, TAction> = (s: TState, a: TAction) => TState;
@@ -162,7 +159,7 @@ declare module "@shakacode/recompose" {
         & { [stateName in TStateName]: TState }
         & { [dispatchName in TDispatchName]: (a: TAction) => void };
     export function withReducer<
-        TOutter,
+        TOuter,
         TState,
         TAction,
         TStateName extends string,
@@ -171,23 +168,23 @@ declare module "@shakacode/recompose" {
         stateName: TStateName,
         dispatchName: TDispatchName,
         reducer: reducer<TState, TAction>,
-        initialState: TState | mapper<TOutter, TState>,
+        initialState: TState | mapper<TOuter, TState>,
     ): InferableComponentEnhancerWithProps<
         reducerProps<TState, TAction, TStateName, TDispatchName>,
-        TOutter
+        TOuter
     >;
 
     // branch: https://github.com/shakacode/recompose/blob/master/docs/API.md#branch
-    export function branch<TOutter>(
-        test: predicate<TOutter>,
-        trueEnhancer: ComponentEnhancer<any, any> | InferableComponentEnhancer<{}>,
-        falseEnhancer?: ComponentEnhancer<any, any> | InferableComponentEnhancer<{}>,
-    ): ComponentEnhancer<any, TOutter>;
+    export function branch<TInner, TOuter>(
+        test: predicate<TOuter>,
+        trueEnhancer: ComponentEnhancer<TInner, TOuter> | InferableComponentEnhancer<{}>,
+        falseEnhancer?: ComponentEnhancer<TInner, TOuter> | InferableComponentEnhancer<{}>,
+    ): ComponentEnhancer<TInner, TOuter>;
 
     // renderComponent: https://github.com/shakacode/recompose/blob/master/docs/API.md#renderComponent
     export function renderComponent<TProps>(
         component: string | Component<TProps>,
-    ): ComponentEnhancer<any, any>;
+    ): ComponentEnhancer<any, TProps>;
 
     // renderNothing: https://github.com/shakacode/recompose/blob/master/docs/API.md#renderNothing
     export const renderNothing: InferableComponentEnhancer<{}>;
@@ -214,7 +211,7 @@ declare module "@shakacode/recompose" {
     // withContext: https://github.com/shakacode/recompose/blob/master/docs/API.md#withContext
     export function withContext<TContext, TProps>(
         childContextTypes: PropTypes.ValidationMap<TContext>,
-        getChildContext: mapper<TProps, any>,
+        getChildContext: mapper<TProps, TContext>,
     ): InferableComponentEnhancer<{}>;
 
     // getContext: https://github.com/shakacode/recompose/blob/master/docs/API.md#getContext
@@ -303,16 +300,16 @@ declare module "@shakacode/recompose" {
     export const toClass: InferableComponentEnhancer<{}>;
 
     // toRenderProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#torenderprops
-    export function toRenderProps<TInner, TOutter>(
-        hoc: InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>,
-    ): FunctionComponent<TOutter & { children: (props: TInner) => React.ReactElement }>;
+    export function toRenderProps<TInner, TOuter>(
+        hoc: InferableComponentEnhancerWithProps<TInner & TOuter, TOuter>,
+    ): FunctionComponent<TOuter & { children: (props: TInner) => React.ReactElement }>;
 
     // fromRenderProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#fromrenderprops
-    export function fromRenderProps<TInner, TOutter, TRenderProps = {}>(
+    export function fromRenderProps<TInner, TOuter, TRenderProps = {}>(
         RenderPropsComponent: Component<any>,
         propsMapper: (props: TRenderProps) => TInner,
         renderPropName?: string,
-    ): ComponentEnhancer<TInner & TOutter, TOutter>;
+    ): ComponentEnhancer<TInner & TOuter, TOuter>;
 
     // Static property helpers: https://github.com/shakacode/recompose/blob/master/docs/API.md#static-property-helpers
 
@@ -335,12 +332,12 @@ declare module "@shakacode/recompose" {
     // Utilities: https://github.com/shakacode/recompose/blob/master/docs/API.md#utilities
 
     // compose: https://github.com/shakacode/recompose/blob/master/docs/API.md#compose
-    export function compose<TInner, TOutter>(
+    export function compose<TInner, TOuter>(
         ...functions: Function[]
-    ): ComponentEnhancer<TInner, TOutter>;
-    // export function compose<TOutter>(
+    ): ComponentEnhancer<TInner, TOuter>;
+    // export function compose<TOuter>(
     //     ...functions: Array<Function>
-    // ): ComponentEnhancer<any, TOutter>;
+    // ): ComponentEnhancer<any, TOuter>;
     // export function compose(
     //     ...functions: Array<Function>
     // ): ComponentEnhancer<any, any>;
@@ -367,23 +364,10 @@ declare module "@shakacode/recompose" {
         value: any,
     ): boolean;
 
-    // createEagerElement: https://github.com/shakacode/recompose/blob/master/docs/API.md#createEagerElement
-    export function createEagerElement(
-        type: Component<any> | string,
-        props?: Object,
-        children?: React.ReactNode,
-    ): React.ReactElement;
-
-    // createEagerFactory: https://github.com/shakacode/recompose/blob/master/docs/API.md#createEagerFactory
-    type componentFactory = (props?: Object, children?: React.ReactNode) => React.ReactElement;
-    export function createEagerFactory(
-        type: Component<any> | string,
-    ): componentFactory;
-
     // createSink: https://github.com/shakacode/recompose/blob/master/docs/API.md#createSink
-    export function createSink(
-        callback: (props: Object) => void,
-    ): React.ComponentClass<any>; // ???
+    export function createSink<TProps = {}>(
+        callback: (props: TProps) => void,
+    ): React.ComponentClass<TProps>;
 
     // componentFromProp: https://github.com/shakacode/recompose/blob/master/docs/API.md#componentFromProp
     export function componentFromProp(
@@ -418,14 +402,14 @@ declare module "@shakacode/recompose" {
     ) => Component<TProps>;
 
     // mapPropsStream: https://github.com/shakacode/recompose/blob/master/docs/API.md#mapPropsStream
-    export function mapPropsStream<TInner, TOutter>(
-        transform: mapper<Subscribable<TOutter>, Subscribable<TInner>>,
-    ): ComponentEnhancer<TInner, TOutter>;
+    export function mapPropsStream<TInner, TOuter>(
+        transform: mapper<Subscribable<TOuter>, Subscribable<TInner>>,
+    ): ComponentEnhancer<TInner, TOuter>;
 
     // mapPropsStreamWithConfig: https://github.com/shakacode/recompose/blob/master/docs/API.md#mappropsstreamwithconfig
-    export function mapPropsStreamWithConfig(config: ObservableConfig): <TInner, TOutter>(
-        transform: mapper<Subscribable<TOutter>, Subscribable<TInner>>,
-    ) => ComponentEnhancer<TInner, TOutter>;
+    export function mapPropsStreamWithConfig(config: ObservableConfig): <TInner, TOuter>(
+        transform: mapper<Subscribable<TOuter>, Subscribable<TInner>>,
+    ) => ComponentEnhancer<TInner, TOuter>;
 
     // createEventHandler: https://github.com/shakacode/recompose/blob/master/docs/API.md#createEventHandler
     type EventHandlerOf<T, TSubs extends Subscribable<T>> = {

--- a/src/packages/recompose/index.d.ts
+++ b/src/packages/recompose/index.d.ts
@@ -157,7 +157,7 @@ declare module "@shakacode/recompose" {
         TDispatchName extends string,
     > =
         & { [stateName in TStateName]: TState }
-        & { [dispatchName in TDispatchName]: (a: TAction) => void };
+        & { [dispatchName in TDispatchName]: (a: TAction, callback?: (newState: TState) => void) => void };
     export function withReducer<
         TOuter,
         TState,

--- a/src/packages/recompose/index.d.ts
+++ b/src/packages/recompose/index.d.ts
@@ -1,0 +1,754 @@
+// @shakacode/recompose is a fork of `recompose`, and these types are based on work done in `@types/recompose`.
+// Source: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/61bebf7cbfd07a3f7a28fd2d8df3ea10a0a8d0a3/types/shakacode__recompose/index.d.ts
+
+/// <reference types="react" />
+
+declare module "@shakacode/recompose" {
+    import type * as PropTypes from "prop-types";
+    import * as React from "react";
+    import { ComponentClass, ComponentType as Component, FunctionComponent } from "react";
+
+    type mapper<TInner, TOutter> = (input: TInner) => TOutter;
+    type predicate<T> = mapper<T, boolean>;
+    type predicateDiff<T> = (current: T, next: T) => boolean;
+
+    // Diff / Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+    type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+    interface Observer<T> {
+        next(props: T): void;
+        complete(): void;
+    }
+
+    interface Subscription {
+        unsubscribe(): void;
+    }
+
+    interface Subscribable<T> {
+        subscribe(observer: Observer<T>): Subscription;
+    }
+
+    interface ComponentEnhancer<TInner, TOutter> {
+        (component: Component<TInner>): ComponentClass<TOutter>;
+    }
+
+    // Injects props and removes them from the prop requirements.
+    // Will not pass through the injected props if they are passed in during
+    // render. Also adds new prop requirements from TNeedsProps.
+    export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
+        <P extends TInjectedProps>(
+            component: Component<P>,
+        ): React.ComponentClass<Omit<P, keyof TInjectedProps> & TNeedsProps>;
+    }
+
+    // Injects props and removes them from the prop requirements.
+    // Will not pass through the injected props if they are passed in during
+    // render.
+    export type InferableComponentEnhancer<TInjectedProps> = InferableComponentEnhancerWithProps<TInjectedProps, {}>;
+
+    // Injects default props and makes them optional. Will still pass through
+    // the injected props if they are passed in during render.
+    export type DefaultingInferableComponentEnhancer<TInjectedProps> = InferableComponentEnhancerWithProps<
+        TInjectedProps,
+        Partial<TInjectedProps>
+    >;
+
+    // Higher-order components: https://github.com/shakacode/recompose/blob/master/docs/API.md#higher-order-components
+
+    // mapProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#mapprops
+    export function mapProps<TInner, TOutter>(
+        propsMapper: mapper<TOutter, TInner>,
+    ): InferableComponentEnhancerWithProps<TInner, TOutter>;
+
+    // withProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#withprops
+    export function withProps<TInner, TOutter>(
+        createProps: TInner | mapper<TOutter, TInner>,
+    ): InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>;
+
+    // withPropsOnChange: https://github.com/shakacode/recompose/blob/master/docs/API.md#withpropsonchange
+    export function withPropsOnChange<TInner, TOutter>(
+        shouldMapOrKeys: string[] | predicateDiff<TOutter>,
+        createProps: mapper<TOutter, TInner>,
+    ): InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>;
+
+    // withHandlers: https://github.com/shakacode/recompose/blob/master/docs/API.md#withhandlers
+    type EventHandler = Function;
+    // This type is required to infer TOutter
+    type HandleCreatorsStructure<TOutter> = {
+        [handlerName: string]: mapper<TOutter, EventHandler>;
+    };
+    // This type is required to infer THandlers
+    type HandleCreatorsHandlers<TOutter, THandlers> = {
+        [P in keyof THandlers]: (props: TOutter) => THandlers[P];
+    };
+    type HandleCreators<TOutter, THandlers> =
+        & HandleCreatorsStructure<TOutter>
+        & HandleCreatorsHandlers<TOutter, THandlers>;
+    type HandleCreatorsFactory<TOutter, THandlers> = (initialProps: TOutter) => HandleCreators<TOutter, THandlers>;
+
+    export function withHandlers<TOutter, THandlers>(
+        handlerCreators:
+            | HandleCreators<TOutter, THandlers>
+            | HandleCreatorsFactory<TOutter, THandlers>,
+    ): InferableComponentEnhancerWithProps<THandlers & TOutter, TOutter>;
+
+    // defaultProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#defaultprops
+    export function defaultProps<T = {}>(
+        props: T,
+    ): DefaultingInferableComponentEnhancer<T>;
+
+    // renameProp: https://github.com/shakacode/recompose/blob/master/docs/API.md#renameProp
+    export function renameProp(
+        outterName: string,
+        innerName: string,
+    ): ComponentEnhancer<any, any>;
+
+    // renameProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#renameProps
+    type NameMap = {
+        [outterName: string]: string;
+    };
+    export function renameProps(
+        nameMap: NameMap,
+    ): ComponentEnhancer<any, any>;
+
+    // flattenProp: https://github.com/shakacode/recompose/blob/master/docs/API.md#flattenProp
+    export function flattenProp(
+        propName: string,
+    ): ComponentEnhancer<any, any>;
+
+    // withState: https://github.com/shakacode/recompose/blob/master/docs/API.md#withState
+    type stateProps<
+        TState,
+        TStateName extends string,
+        TStateUpdaterName extends string,
+    > =
+        & { [stateName in TStateName]: TState }
+        & { [stateUpdateName in TStateUpdaterName]: (state: TState) => TState };
+    export function withState<
+        TOutter,
+        TState,
+        TStateName extends string,
+        TStateUpdaterName extends string,
+    >(
+        stateName: TStateName,
+        stateUpdaterName: TStateUpdaterName,
+        initialState: TState | mapper<TOutter, TState>,
+    ): InferableComponentEnhancerWithProps<
+        stateProps<TState, TStateName, TStateUpdaterName>,
+        TOutter
+    >;
+
+    // withStateHandlers: https://github.com/shakacode/recompose/blob/master/docs/API.md#withstatehandlers
+    type StateHandler<TState> = (...payload: any[]) => Partial<TState> | undefined;
+    type StateHandlerMap<TState> = {
+        [updaterName: string]: StateHandler<TState>;
+    };
+    type StateUpdaters<TOutter, TState, TUpdaters> = {
+        [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => TUpdaters[updaterName];
+    };
+    export function withStateHandlers<TState, TUpdaters extends StateHandlerMap<TState>, TOutter = {}>(
+        createProps: TState | mapper<TOutter, TState>,
+        stateUpdaters: StateUpdaters<TOutter, TState, TUpdaters>,
+    ): InferableComponentEnhancerWithProps<TOutter & TState & TUpdaters, TOutter>;
+
+    // withReducer: https://github.com/shakacode/recompose/blob/master/docs/API.md#withReducer
+    type reducer<TState, TAction> = (s: TState, a: TAction) => TState;
+    type reducerProps<
+        TState,
+        TAction,
+        TStateName extends string,
+        TDispatchName extends string,
+    > =
+        & { [stateName in TStateName]: TState }
+        & { [dispatchName in TDispatchName]: (a: TAction) => void };
+    export function withReducer<
+        TOutter,
+        TState,
+        TAction,
+        TStateName extends string,
+        TDispatchName extends string,
+    >(
+        stateName: TStateName,
+        dispatchName: TDispatchName,
+        reducer: reducer<TState, TAction>,
+        initialState: TState | mapper<TOutter, TState>,
+    ): InferableComponentEnhancerWithProps<
+        reducerProps<TState, TAction, TStateName, TDispatchName>,
+        TOutter
+    >;
+
+    // branch: https://github.com/shakacode/recompose/blob/master/docs/API.md#branch
+    export function branch<TOutter>(
+        test: predicate<TOutter>,
+        trueEnhancer: ComponentEnhancer<any, any> | InferableComponentEnhancer<{}>,
+        falseEnhancer?: ComponentEnhancer<any, any> | InferableComponentEnhancer<{}>,
+    ): ComponentEnhancer<any, TOutter>;
+
+    // renderComponent: https://github.com/shakacode/recompose/blob/master/docs/API.md#renderComponent
+    export function renderComponent<TProps>(
+        component: string | Component<TProps>,
+    ): ComponentEnhancer<any, any>;
+
+    // renderNothing: https://github.com/shakacode/recompose/blob/master/docs/API.md#renderNothing
+    export const renderNothing: InferableComponentEnhancer<{}>;
+
+    // shouldUpdate: https://github.com/shakacode/recompose/blob/master/docs/API.md#shouldUpdate
+    export function shouldUpdate<TProps>(
+        test: predicateDiff<TProps>,
+    ): InferableComponentEnhancer<{}>;
+
+    // pure: https://github.com/shakacode/recompose/blob/master/docs/API.md#pure
+    export function pure<TProps>(component: Component<TProps>): Component<TProps>;
+
+    // onlyUpdateForKeys: https://github.com/shakacode/recompose/blob/master/docs/API.md#onlyUpdateForKeys
+    export function onlyUpdateForKeys(
+        propKeys: string[],
+    ): InferableComponentEnhancer<{}>;
+    export function onlyUpdateForKeys<T>(
+        propKeys: Array<keyof T>,
+    ): InferableComponentEnhancer<{}>;
+
+    // onlyUpdateForPropTypes: https://github.com/shakacode/recompose/blob/master/docs/API.md#onlyUpdateForPropTypes
+    export const onlyUpdateForPropTypes: InferableComponentEnhancer<{}>;
+
+    // withContext: https://github.com/shakacode/recompose/blob/master/docs/API.md#withContext
+    export function withContext<TContext, TProps>(
+        childContextTypes: PropTypes.ValidationMap<TContext>,
+        getChildContext: mapper<TProps, any>,
+    ): InferableComponentEnhancer<{}>;
+
+    // getContext: https://github.com/shakacode/recompose/blob/master/docs/API.md#getContext
+    export function getContext<TContext>(
+        contextTypes: PropTypes.ValidationMap<TContext>,
+    ): InferableComponentEnhancer<TContext>;
+
+    interface _ReactLifeCycleFunctionsThisArguments<TProps, TState> {
+        props: TProps;
+        state: TState;
+        setState<TKeyOfState extends keyof TState>(
+            f: (prevState: TState, props: TProps) => Pick<TState, TKeyOfState>,
+            callback?: () => any,
+        ): void;
+        setState<TKeyOfState extends keyof TState>(state: Pick<TState, TKeyOfState>, callback?: () => any): void;
+        forceUpdate(callBack?: () => any): void;
+
+        context: any;
+        refs: {
+            [key: string]: React.ReactInstance;
+        };
+    }
+    type ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance = {}> =
+        & _ReactLifeCycleFunctionsThisArguments<TProps, TState>
+        & TInstance;
+
+    // lifecycle: https://github.com/shakacode/recompose/blob/master/docs/API.md#lifecycle
+    interface ReactLifeCycleFunctions<TProps, TState, TInstance = {}> {
+        componentWillMount?:
+            | ((this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>) => void)
+            | undefined;
+        UNSAFE_componentWillMount?(this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>): void;
+        componentDidMount?:
+            | ((this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>) => void)
+            | undefined;
+        componentWillReceiveProps?:
+            | ((this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>, nextProps: TProps) => void)
+            | undefined;
+        UNSAFE_componentWillReceiveProps?(
+            this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>,
+            nextProps: TProps,
+        ): void;
+        shouldComponentUpdate?:
+            | ((
+                this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>,
+                nextProps: TProps,
+                nextState: TState,
+            ) => boolean)
+            | undefined;
+        componentWillUpdate?:
+            | ((
+                this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>,
+                nextProps: TProps,
+                nextState: TState,
+            ) => void)
+            | undefined;
+        UNSAFE_componentWillUpdate?(
+            this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>,
+            nextProps: TProps,
+            nextState: TState,
+        ): void;
+        componentDidUpdate?:
+            | ((
+                this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>,
+                prevProps: TProps,
+                prevState: TState,
+            ) => void)
+            | undefined;
+        componentWillUnmount?:
+            | ((this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>) => void)
+            | undefined;
+        componentDidCatch?:
+            | ((
+                this: ReactLifeCycleFunctionsThisArguments<TProps, TState, TInstance>,
+                error: Error,
+                info: React.ErrorInfo,
+            ) => void)
+            | undefined;
+    }
+
+    export function lifecycle<TProps, TState, TInstance = {}>(
+        spec: ReactLifeCycleFunctions<TProps, TState, TInstance> & TInstance,
+    ): InferableComponentEnhancer<{}>;
+
+    // toClass: https://github.com/shakacode/recompose/blob/master/docs/API.md#toClass
+    export const toClass: InferableComponentEnhancer<{}>;
+
+    // toRenderProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#torenderprops
+    export function toRenderProps<TInner, TOutter>(
+        hoc: InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>,
+    ): FunctionComponent<TOutter & { children: (props: TInner) => React.ReactElement }>;
+
+    // fromRenderProps: https://github.com/shakacode/recompose/blob/master/docs/API.md#fromrenderprops
+    export function fromRenderProps<TInner, TOutter, TRenderProps = {}>(
+        RenderPropsComponent: Component<any>,
+        propsMapper: (props: TRenderProps) => TInner,
+        renderPropName?: string,
+    ): ComponentEnhancer<TInner & TOutter, TOutter>;
+
+    // Static property helpers: https://github.com/shakacode/recompose/blob/master/docs/API.md#static-property-helpers
+
+    // setStatic: https://github.com/shakacode/recompose/blob/master/docs/API.md#setStatic
+    export function setStatic(
+        key: string,
+        value: any,
+    ): <T extends Component<any>>(component: T) => T;
+
+    // setPropTypes: https://github.com/shakacode/recompose/blob/master/docs/API.md#setPropTypes
+    export function setPropTypes<P>(
+        propTypes: PropTypes.ValidationMap<P>,
+    ): <T extends Component<P>>(component: T) => T;
+
+    // setDisplayName: https://github.com/shakacode/recompose/blob/master/docs/API.md#setDisplayName
+    export function setDisplayName(
+        displayName: string,
+    ): <T extends Component<any>>(component: T) => T;
+
+    // Utilities: https://github.com/shakacode/recompose/blob/master/docs/API.md#utilities
+
+    // compose: https://github.com/shakacode/recompose/blob/master/docs/API.md#compose
+    export function compose<TInner, TOutter>(
+        ...functions: Function[]
+    ): ComponentEnhancer<TInner, TOutter>;
+    // export function compose<TOutter>(
+    //     ...functions: Array<Function>
+    // ): ComponentEnhancer<any, TOutter>;
+    // export function compose(
+    //     ...functions: Array<Function>
+    // ): ComponentEnhancer<any, any>;
+
+    // getDisplayName: https://github.com/shakacode/recompose/blob/master/docs/API.md#getDisplayName
+    export function getDisplayName(
+        component: Component<any> | string,
+    ): string;
+
+    // wrapDisplayName: https://github.com/shakacode/recompose/blob/master/docs/API.md#wrapDisplayName
+    export function wrapDisplayName(
+        component: Component<any> | string,
+        wrapperName: string,
+    ): string;
+
+    // shallowEqual: https://github.com/shakacode/recompose/blob/master/docs/API.md#shallowEqual
+    export function shallowEqual(
+        a: Object,
+        b: Object,
+    ): boolean;
+
+    // isClassComponent: https://github.com/shakacode/recompose/blob/master/docs/API.md#isClassComponent
+    export function isClassComponent(
+        value: any,
+    ): boolean;
+
+    // createEagerElement: https://github.com/shakacode/recompose/blob/master/docs/API.md#createEagerElement
+    export function createEagerElement(
+        type: Component<any> | string,
+        props?: Object,
+        children?: React.ReactNode,
+    ): React.ReactElement;
+
+    // createEagerFactory: https://github.com/shakacode/recompose/blob/master/docs/API.md#createEagerFactory
+    type componentFactory = (props?: Object, children?: React.ReactNode) => React.ReactElement;
+    export function createEagerFactory(
+        type: Component<any> | string,
+    ): componentFactory;
+
+    // createSink: https://github.com/shakacode/recompose/blob/master/docs/API.md#createSink
+    export function createSink(
+        callback: (props: Object) => void,
+    ): React.ComponentClass<any>; // ???
+
+    // componentFromProp: https://github.com/shakacode/recompose/blob/master/docs/API.md#componentFromProp
+    export function componentFromProp(
+        propName: string,
+    ): FunctionComponent<any>;
+
+    // nest: https://github.com/shakacode/recompose/blob/master/docs/API.md#nest
+    export function nest(
+        ...Components: Array<string | Component<any>>
+    ): React.ComponentClass<any>; // ???
+
+    // hoistStatics: https://github.com/shakacode/recompose/blob/master/docs/API.md#hoistStatics
+    export function hoistStatics<TInner, TOuter>(
+        hoc: InferableComponentEnhancerWithProps<TInner, TOuter>,
+        blacklist?: { [key: string]: boolean },
+    ): InferableComponentEnhancerWithProps<TInner, TOuter>;
+    export function hoistStatics<TProps>(
+        hoc: InferableComponentEnhancer<TProps>,
+        blacklist?: { [key: string]: boolean },
+    ): InferableComponentEnhancer<TProps>;
+
+    // Observable utilities: https://github.com/shakacode/recompose/blob/master/docs/API.md#observable-utilities
+
+    // componentFromStream: https://github.com/shakacode/recompose/blob/master/docs/API.md#componentFromStream
+    export function componentFromStream<TProps>(
+        propsToReactNode: mapper<Subscribable<TProps>, Subscribable<React.ReactNode>>,
+    ): Component<TProps>; // ???
+
+    // componentFromStreamWithConfig: https://github.com/shakacode/recompose/blob/master/docs/API.md#componentfromstreamwithconfig
+    export function componentFromStreamWithConfig(config: ObservableConfig): <TProps>(
+        propsToReactNode: mapper<Subscribable<TProps>, Subscribable<React.ReactNode>>,
+    ) => Component<TProps>;
+
+    // mapPropsStream: https://github.com/shakacode/recompose/blob/master/docs/API.md#mapPropsStream
+    export function mapPropsStream<TInner, TOutter>(
+        transform: mapper<Subscribable<TOutter>, Subscribable<TInner>>,
+    ): ComponentEnhancer<TInner, TOutter>;
+
+    // mapPropsStreamWithConfig: https://github.com/shakacode/recompose/blob/master/docs/API.md#mappropsstreamwithconfig
+    export function mapPropsStreamWithConfig(config: ObservableConfig): <TInner, TOutter>(
+        transform: mapper<Subscribable<TOutter>, Subscribable<TInner>>,
+    ) => ComponentEnhancer<TInner, TOutter>;
+
+    // createEventHandler: https://github.com/shakacode/recompose/blob/master/docs/API.md#createEventHandler
+    type EventHandlerOf<T, TSubs extends Subscribable<T>> = {
+        handler: (value: T) => void;
+        stream: TSubs;
+    };
+    export function createEventHandler<T, TSubs extends Subscribable<T>>(): EventHandlerOf<T, TSubs>;
+
+    // createEventHandlerWithConfig: https://github.com/shakacode/recompose/blob/master/docs/API.md#createEventHandlerWithConfig
+    export function createEventHandlerWithConfig(
+        config: ObservableConfig,
+    ): <T, TSubs extends Subscribable<T>>() => EventHandlerOf<T, TSubs>;
+
+    // setObservableConfig: https://github.com/shakacode/recompose/blob/master/docs/API.md#setObservableConfig
+    export type ObservableConfig = {
+        fromESObservable?: (<T>(observable: Subscribable<T>) => any) | undefined;
+        toESObservable?: (<T>(stream: any) => Subscribable<T>) | undefined;
+    };
+    export function setObservableConfig(config: ObservableConfig): void;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#rxjs
+declare module "@shakacode/recompose/rxjsObservableConfig" {
+    import { ObservableConfig } from "@shakacode/recompose";
+
+    const rxjsconfig: ObservableConfig;
+
+    export default rxjsconfig;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#rxjs-4-legacy
+declare module "@shakacode/recompose/rxjs4ObservableConfig" {
+    import { ObservableConfig } from "@shakacode/recompose";
+
+    const rxjs4config: ObservableConfig;
+
+    export default rxjs4config;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#most
+declare module "@shakacode/recompose/mostObservableConfig" {
+    import { ObservableConfig } from "@shakacode/recompose";
+
+    const mostConfig: ObservableConfig;
+
+    export default mostConfig;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#xstream
+declare module "@shakacode/recompose/xstreamObservableConfig" {
+    import { ObservableConfig } from "@shakacode/recompose";
+
+    const xstreamConfig: ObservableConfig;
+
+    export default xstreamConfig;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#bacon
+declare module "@shakacode/recompose/baconObservableConfig" {
+    import { ObservableConfig } from "@shakacode/recompose";
+
+    const baconConfig: ObservableConfig;
+
+    export default baconConfig;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#kefir
+declare module "@shakacode/recompose/kefirObservableConfig" {
+    import { ObservableConfig } from "@shakacode/recompose";
+
+    const kefirConfig: ObservableConfig;
+
+    export default kefirConfig;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#flyd
+declare module "@shakacode/recompose/flydObservableConfig" {
+    import { ObservableConfig } from "@shakacode/recompose";
+
+    const flydConfig: ObservableConfig;
+
+    export default flydConfig;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#mapprops
+declare module "@shakacode/recompose/mapProps" {
+    import { mapProps } from "@shakacode/recompose";
+    export default mapProps;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#withprops
+declare module "@shakacode/recompose/withProps" {
+    import { withProps } from "@shakacode/recompose";
+    export default withProps;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#withpropsonchange
+declare module "@shakacode/recompose/withPropsOnChange" {
+    import { withPropsOnChange } from "@shakacode/recompose";
+    export default withPropsOnChange;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#withhandlers
+declare module "@shakacode/recompose/withHandlers" {
+    import { withHandlers } from "@shakacode/recompose";
+    export default withHandlers;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#defaultprops
+declare module "@shakacode/recompose/defaultProps" {
+    import { defaultProps } from "@shakacode/recompose";
+    export default defaultProps;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#renameprop
+declare module "@shakacode/recompose/renameProp" {
+    import { renameProp } from "@shakacode/recompose";
+    export default renameProp;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#renameprops
+declare module "@shakacode/recompose/renameProps" {
+    import { renameProps } from "@shakacode/recompose";
+    export default renameProps;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#flattenprop
+declare module "@shakacode/recompose/flattenProp" {
+    import { flattenProp } from "@shakacode/recompose";
+    export default flattenProp;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#withstate
+declare module "@shakacode/recompose/withState" {
+    import { withState } from "@shakacode/recompose";
+    export default withState;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#withstatehandlers
+declare module "@shakacode/recompose/withStateHandlers" {
+    import { withStateHandlers } from "@shakacode/recompose";
+    export default withStateHandlers;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#withreducer
+declare module "@shakacode/recompose/withReducer" {
+    import { withReducer } from "@shakacode/recompose";
+    export default withReducer;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#branch
+declare module "@shakacode/recompose/branch" {
+    import { branch } from "@shakacode/recompose";
+    export default branch;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#rendercomponent
+declare module "@shakacode/recompose/renderComponent" {
+    import { renderComponent } from "@shakacode/recompose";
+    export default renderComponent;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#rendernothing
+declare module "@shakacode/recompose/renderNothing" {
+    import { renderNothing } from "@shakacode/recompose";
+    export default renderNothing;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#shouldupdate
+declare module "@shakacode/recompose/shouldUpdate" {
+    import { shouldUpdate } from "@shakacode/recompose";
+    export default shouldUpdate;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#pure
+declare module "@shakacode/recompose/pure" {
+    import { pure } from "@shakacode/recompose";
+    export default pure;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#onlyupdateforkeys
+declare module "@shakacode/recompose/onlyUpdateForKeys" {
+    import { onlyUpdateForKeys } from "@shakacode/recompose";
+    export default onlyUpdateForKeys;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#onlyupdateforproptypes
+declare module "@shakacode/recompose/onlyUpdateForPropTypes" {
+    import { onlyUpdateForPropTypes } from "@shakacode/recompose";
+    export default onlyUpdateForPropTypes;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#withcontext
+declare module "@shakacode/recompose/withContext" {
+    import { withContext } from "@shakacode/recompose";
+    export default withContext;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#getcontext
+declare module "@shakacode/recompose/getContext" {
+    import { getContext } from "@shakacode/recompose";
+    export default getContext;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#lifecycle
+declare module "@shakacode/recompose/lifecycle" {
+    import { lifecycle } from "@shakacode/recompose";
+    export default lifecycle;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#toclass
+declare module "@shakacode/recompose/toClass" {
+    import { toClass } from "@shakacode/recompose";
+    export default toClass;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#torenderprops
+declare module "@shakacode/recompose/toRenderProps" {
+    import { toRenderProps } from "@shakacode/recompose";
+    export default toRenderProps;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#fromrenderprops
+declare module "@shakacode/recompose/fromRenderProps" {
+    import { fromRenderProps } from "@shakacode/recompose";
+    export default fromRenderProps;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#setstatic
+declare module "@shakacode/recompose/setStatic" {
+    import { setStatic } from "@shakacode/recompose";
+    export default setStatic;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#setproptypes
+declare module "@shakacode/recompose/setPropTypes" {
+    import { setPropTypes } from "@shakacode/recompose";
+    export default setPropTypes;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#setdisplayname
+declare module "@shakacode/recompose/setDisplayName" {
+    import { setDisplayName } from "@shakacode/recompose";
+    export default setDisplayName;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#compose
+declare module "@shakacode/recompose/compose" {
+    import { compose } from "@shakacode/recompose";
+    export default compose;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#getdisplayname
+declare module "@shakacode/recompose/getDisplayName" {
+    import { getDisplayName } from "@shakacode/recompose";
+    export default getDisplayName;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#wrapdisplayname
+declare module "@shakacode/recompose/wrapDisplayName" {
+    import { wrapDisplayName } from "@shakacode/recompose";
+    export default wrapDisplayName;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#shallowequal
+declare module "@shakacode/recompose/shallowEqual" {
+    import { shallowEqual } from "@shakacode/recompose";
+    export default shallowEqual;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#isclasscomponent
+declare module "@shakacode/recompose/isClassComponent" {
+    import { isClassComponent } from "@shakacode/recompose";
+    export default isClassComponent;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#createsink
+declare module "@shakacode/recompose/createSink" {
+    import { createSink } from "@shakacode/recompose";
+    export default createSink;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#componentfromprop
+declare module "@shakacode/recompose/componentFromProp" {
+    import { componentFromProp } from "@shakacode/recompose";
+    export default componentFromProp;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#nest
+declare module "@shakacode/recompose/nest" {
+    import { nest } from "@shakacode/recompose";
+    export default nest;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#hoiststatics
+declare module "@shakacode/recompose/hoistStatics" {
+    import { hoistStatics } from "@shakacode/recompose";
+    export default hoistStatics;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#componentfromstream
+declare module "@shakacode/recompose/componentFromStream" {
+    import { componentFromStream } from "@shakacode/recompose";
+    export { componentFromStreamWithConfig } from "@shakacode/recompose";
+    export default componentFromStream;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#mappropsstream
+declare module "@shakacode/recompose/mapPropsStream" {
+    import { mapPropsStream } from "@shakacode/recompose";
+    export { mapPropsStreamWithConfig } from "@shakacode/recompose";
+    export default mapPropsStream;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#createeventhandler
+declare module "@shakacode/recompose/createEventHandler" {
+    import { createEventHandler } from "@shakacode/recompose";
+    export { createEventHandlerWithConfig } from "@shakacode/recompose";
+    export default createEventHandler;
+}
+
+// https://github.com/shakacode/recompose/blob/master/docs/API.md#setobservableconfig
+declare module "@shakacode/recompose/setObservableConfig" {
+    import { setObservableConfig } from "@shakacode/recompose";
+    export default setObservableConfig;
+}

--- a/src/packages/recompose/package.json
+++ b/src/packages/recompose/package.json
@@ -11,6 +11,7 @@
   ],
   "main": "dist/Recompose.cjs.js",
   "module": "dist/Recompose.esm.js",
+  "types": "index.d.ts",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "change-emitter": "^0.1.2",


### PR DESCRIPTION
## Summary

- Copy `index.d.ts` from [@types/shakacode__recompose](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/61bebf7cbfd07a3f7a28fd2d8df3ea10a0a8d0a3/types/shakacode__recompose/index.d.ts) into the package so types ship with the library
- Add `"types": "index.d.ts"` to package.json

## Test plan

- [ ] Verify TypeScript consumers can import types without `@types/shakacode__recompose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive TypeScript typings for the recompose public API, including observable integrations and per-module type surfaces for better IDE support.

* **Documentation**
  * Updated API docs and examples to TypeScript, with generic signatures for HOCs, state helpers, lifecycle, and observable utilities.

* **Chores**
  * Published typings entry in package metadata so TypeScript tooling can discover the declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->