### PR TITLE
Add OTP prompt to release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -139,8 +139,12 @@ try {
     exit(0)
   }
 
+  const otp = readline.question('Enter your npm OTP code: ')
+
   log('Publishing...')
-  if (exec(`cd ${outDir} && npm publish --access public `).code !== 0) {
+  if (
+    exec(`cd ${outDir} && npm publish --access public --otp=${otp}`).code !== 0
+  ) {
     logError('Publish failed. Aborting release.')
     exit(1)
   }


### PR DESCRIPTION
## Summary
- Adds an interactive OTP prompt before `npm publish` in the release script
- Required because npm publish fails with `EOTP` when 2FA is enabled

## Test plan
- [ ] Run `yarn release` and verify OTP prompt appears before publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security for the npm release process by requiring OTP (One-Time Password) authentication before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->